### PR TITLE
Add aliases for numeric types

### DIFF
--- a/Core/BUILD
+++ b/Core/BUILD
@@ -3,8 +3,6 @@ load("//tools:bengine_rules.bzl", "bengine_cc_library", "bengine_cc_test")
 package(default_visibility = ["//visibility:public"])
 
 bengine_cc_library(
-    name = "assert",
-    srcs = ["Assert.cpp"],
-    hdrs = ["Assert.h"],
-    deps = ["//core/logging"],
+    name = "types",
+    hdrs = ["Types.h"],
 )

--- a/Core/Types.h
+++ b/Core/Types.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+using byte = std::byte;
+
+using i8  = int8_t;
+using i16 = int16_t;
+using i32 = int32_t;
+using i64 = int64_t;
+
+using u8  = uint8_t;
+using u16 = uint16_t;
+using u32 = uint32_t;
+using u64 = uint64_t;
+
+using f32 = float;
+using f64 = double;

--- a/Core/assert/Assert.cpp
+++ b/Core/assert/Assert.cpp
@@ -1,6 +1,6 @@
 #include "core/assert/Assert.h"
 
-#include <boost/stacktrace.hpp>
+#include <stacktrace>
 
 namespace Core {
 namespace internal {
@@ -8,7 +8,7 @@ LogCategory AssertLog("assert");
 }
 std::string GetBacktraceAsString(uint32_t frameToSkip) {
     // constexpr uint32_t maxFrames = std::numeric_limits<uint32_t>::max();
-    return boost::stacktrace::to_string(boost::stacktrace::stacktrace(frameToSkip, 9999));
+    return std::to_string(std::stacktrace::current(frameToSkip));
 }
 
 void Abort() {

--- a/Core/assert/Assert.h
+++ b/Core/assert/Assert.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "core/Types.h"
 #include "core/logging/Logger.h"
 
 #include <fmt/format.h>
@@ -11,9 +12,9 @@ namespace internal {
 extern LogCategory AssertLog;
 }
 
-// The default skip of three frames (2 for boost functions, one for this functions) will give a stack trace pointing to
+// The default skip of three frames (2 for std functions, one for this functions) will give a stack trace pointing to
 // the caller of this function.
-std::string GetBacktraceAsString(uint32_t framesToSkip = 3);
+std::string GetBacktraceAsString(u32 framesToSkip = 3);
 
 [[noreturn]] void Abort();
 

--- a/Core/containers/Array.h
+++ b/Core/containers/Array.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "core/Types.h"
 #include "core/assert/Assert.h"
 
 #include "core/io/serialization/InputStream.h"
@@ -13,23 +14,23 @@
 
 namespace Core {
 
-template <typename T, uint64_t SIZE>
+template <typename T, u64 SIZE>
 using FixedArray = std::array<T, SIZE>;
 
 template <typename T>
 class Array {
 public:
-    constexpr static uint64_t MinimumCapacity = 4;
-    constexpr static uint64_t ElementSize     = sizeof(T);
-    constexpr static float GrowthFactor       = 1.5f;
+    constexpr static u64 MinimumCapacity = 4;
+    constexpr static u64 ElementSize     = sizeof(T);
+    constexpr static f32 GrowthFactor    = 1.5f;
 
     using ElementType = T;
 
-    explicit Array(uint64_t initialCapacity = 4);
+    explicit Array(u64 initialCapacity = 4);
 
     explicit Array(Core::Span<T> elementsToCopy);
 
-    Array(const T& original, uint64_t repeatCount);
+    Array(const T& original, u64 repeatCount);
     Array(std::initializer_list<T> initializerList);
     Array(const Array<T>& other);
     Array(Array<T>&& other);
@@ -39,17 +40,17 @@ public:
 
     ~Array();
 
-    [[nodiscard]] T& operator[](uint64_t i);
-    [[nodiscard]] const T& operator[](uint64_t i) const;
+    [[nodiscard]] T& operator[](u64 i);
+    [[nodiscard]] const T& operator[](u64 i) const;
 
     template <typename... ARGS>
-    T& emplaceAt(uint64_t index, ARGS&&... args);
+    T& emplaceAt(u64 index, ARGS&&... args);
 
     template <typename... ARGS>
     T& emplace(ARGS&&... args);
 
-    T& insertAt(uint64_t index, const T& elementToInsert);
-    T& insertAt(uint64_t index, T&& elementToInsert);
+    T& insertAt(u64 index, const T& elementToInsert);
+    T& insertAt(u64 index, T&& elementToInsert);
 
     T& insert(const T& elementToInsert);
     T& insert(T&& elementToInsert);
@@ -57,15 +58,15 @@ public:
     template <typename U>
     Core::Span<T> insertAll(Core::Span<U> elements);
 
-    [[nodiscard]] Core::Span<T> insertUninitialized(uint64_t newElementCount);
+    [[nodiscard]] Core::Span<T> insertUninitialized(u64 newElementCount);
 
-    void eraseAt(uint64_t index, uint64_t elementsToErase = 1);
+    void eraseAt(u64 index, u64 elementsToErase = 1);
 
     void clear();
 
-    [[nodiscard]] uint64_t count() const;
-    [[nodiscard]] uint64_t totalCapacity() const;
-    [[nodiscard]] uint64_t unusedCapacity() const;
+    [[nodiscard]] u64 count() const;
+    [[nodiscard]] u64 totalCapacity() const;
+    [[nodiscard]] u64 unusedCapacity() const;
     [[nodiscard]] bool isEmpty() const;
     [[nodiscard]] T* rawData();
     [[nodiscard]] const T* rawData() const;
@@ -74,20 +75,20 @@ public:
     [[nodiscard]] T* end();
     [[nodiscard]] const T* end() const;
 
-    void ensureCapacity(uint64_t requiredCapacity);
+    void ensureCapacity(u64 requiredCapacity);
 
 protected:
     void destructAllElements();
 
-    static void CopyElementMemory(T* destination, const T* source, uint64_t elementCount);
-    static void MoveElementMemory(T* destination, const T* source, uint64_t elementCount);
+    static void CopyElementMemory(T* destination, const T* source, u64 elementCount);
+    static void MoveElementMemory(T* destination, const T* source, u64 elementCount);
 
-    void shiftElementsLeft(uint64_t startIndex, uint64_t distance);
-    void shiftElementsRight(uint64_t startIndex, uint64_t distance);
+    void shiftElementsLeft(u64 startIndex, u64 distance);
+    void shiftElementsRight(u64 startIndex, u64 distance);
 
-    uint64_t capacity;
-    uint64_t elementCount = 0;
-    T* data               = nullptr;
+    u64 capacity;
+    u64 elementCount = 0;
+    T* data          = nullptr;
 };
 
 template <typename T>
@@ -100,12 +101,12 @@ Core::Span<const T> ToSpan(const Core::Array<T>& array) {
     return Core::Span<const T>(array.rawData(), array.count());
 }
 
-template <typename T, uint64_t SIZE>
+template <typename T, u64 SIZE>
 Core::Span<T> ToSpan(Core::FixedArray<T, SIZE>& array) {
     return Core::Span<T>(array.data(), SIZE);
 }
 
-template <typename T, uint64_t SIZE>
+template <typename T, u64 SIZE>
 Core::Span<const T> ToSpan(const Core::FixedArray<T, SIZE>& array) {
     return Core::Span<T>(array.data(), SIZE);
 }
@@ -120,12 +121,12 @@ Core::Span<const std::byte> AsBytes(const Core::Array<T>& array) requires std::i
     return Core::AsBytes(ToSpan(array));
 }
 
-template <typename T, uint64_t SIZE>
+template <typename T, u64 SIZE>
 Core::Span<std::byte> AsBytes(Core::FixedArray<T, SIZE>& array) requires std::is_trivially_copyable_v<T> {
     return Core::AsWritableBytes(ToSpan(array));
 }
 
-template <typename T, uint64_t SIZE>
+template <typename T, u64 SIZE>
 Core::Span<const std::byte> AsBytes(const Core::FixedArray<T, SIZE>& array) requires std::is_trivially_copyable_v<T> {
     return Core::AsBytes(ToSpan(array));
 }
@@ -148,7 +149,7 @@ struct Serializer<Core::Array<T>> {
     }
 };
 
-template <typename T, uint64_t SIZE>
+template <typename T, u64 SIZE>
 struct Serializer<Core::FixedArray<T, SIZE>> {
     static void serialize(OutputStream& stream, const Core::FixedArray<T, SIZE>& values) {
         stream.write(values.size());
@@ -165,7 +166,7 @@ struct Serializer<Core::FixedArray<T, SIZE>> {
 template <typename T>
 struct Deserializer<Core::Array<T>> {
     static Core::Array<T> deserialize(InputStream& stream) {
-        uint64_t elementCount = stream.read<uint64_t>();
+        u64 elementCount = stream.read<u64>();
         Core::Array<T> value;
 
         if constexpr(BinarySerializable<T>) {
@@ -179,7 +180,7 @@ struct Deserializer<Core::Array<T>> {
     }
 };
 
-template <typename T, uint64_t SIZE>
+template <typename T, u64 SIZE>
 struct Deserializer<Core::FixedArray<T, SIZE>> {
     static Core::FixedArray<T, SIZE> deserialize(InputStream& stream) {
         size_t elementCount = stream.read<Core::FixedArray<T, SIZE>::size_type>();

--- a/Core/containers/IndexSpan.h
+++ b/Core/containers/IndexSpan.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "core/Types.h"
 #include "core/assert/Assert.h"
 #include "core/containers/Array.h"
 #include "core/io/serialization/InputStream.h"
@@ -9,18 +10,18 @@
 namespace Core {
 
 struct IndexSpan {
-    uint64_t start;
-    uint64_t count;
+    u64 start;
+    u64 count;
 
-    IndexSpan(uint64_t count) : IndexSpan(0, count) {}
-    IndexSpan(uint64_t start, uint64_t count) : start(start), count(count) {}
+    IndexSpan(u64 count) : IndexSpan(0, count) {}
+    IndexSpan(u64 start, u64 count) : start(start), count(count) {}
 
-    uint64_t operator[](uint64_t index) const {
+    u64 operator[](u64 index) const {
         ASSERT(index < count);
         return start + index;
     }
 
-    IndexSpan slice(uint64_t offset, uint64_t count) {
+    IndexSpan slice(u64 offset, u64 count) {
         ASSERT(count + offset < this->count);
         return IndexSpan(start + offset, count);
     }
@@ -39,8 +40,8 @@ struct Serializer<Core::IndexSpan> {
 template <>
 struct Deserializer<Core::IndexSpan> {
     static Core::IndexSpan deserialize(InputStream& stream) {
-        uint64_t start = stream.read<uint64_t>();
-        uint64_t count = stream.read<uint64_t>();
+        u64 start = stream.read<u64>();
+        u64 count = stream.read<u64>();
         return Core::IndexSpan(start, count);
     }
 };

--- a/Core/containers/OpaqueID.h
+++ b/Core/containers/OpaqueID.h
@@ -4,9 +4,11 @@
 #include <ostream>
 #include <type_traits>
 
+#include "core/Types.h"
+
 namespace Core {
 
-template <typename LABEL, typename BASE_TYPE = uint64_t>
+template <typename LABEL, typename BASE_TYPE = u64>
 class OpaqueID {
     static_assert(std::is_integral_v<BASE_TYPE>());
 

--- a/Core/containers/Span.h
+++ b/Core/containers/Span.h
@@ -4,6 +4,8 @@
 #include <span>
 #include <type_traits>
 
+#include "core/Types.h"
+
 namespace Core {
 
 
@@ -12,7 +14,7 @@ class Span {
 public:
     using ElementType = T;
 
-    Span(T* elements, uint64_t count);
+    Span(T* elements, u64 count);
     Span(const Span<T>& other) = default;
 
     template <size_t EXTENT>
@@ -26,17 +28,17 @@ public:
     template <typename U, typename = std::enable_if_t<std::is_same_v<const U, T> && !std::is_same_v<U, T>>>
     Span<T>& operator=(Span<U> other);
 
-    [[nodiscard]] T& operator[](uint64_t i);
-    [[nodiscard]] const T& operator[](uint64_t i) const;
+    [[nodiscard]] T& operator[](u64 i);
+    [[nodiscard]] const T& operator[](u64 i) const;
 
-    void truncateFront(uint64_t count);
-    void truncateBack(uint64_t count);
+    void truncateFront(u64 count);
+    void truncateBack(u64 count);
 
-    Span<T> first(uint64_t count);
-    Span<T> last(uint64_t count);
-    Span<T> subspan(uint64_t offset, uint64_t count) const;
+    Span<T> first(u64 count);
+    Span<T> last(u64 count);
+    Span<T> subspan(u64 offset, u64 count) const;
 
-    [[nodiscard]] uint64_t count() const;
+    [[nodiscard]] u64 count() const;
     [[nodiscard]] bool isEmpty() const;
     [[nodiscard]] T* rawData();
     [[nodiscard]] const T* rawData() const;
@@ -46,18 +48,18 @@ public:
     [[nodiscard]] const T* end() const;
 
 private:
-    uint64_t elementCount = 0;
-    T* data               = nullptr;
+    u64 elementCount = 0;
+    T* data          = nullptr;
 };
 
 template <typename T>
-Span<const std::byte> AsBytes(Span<T> span) {
-    return Span<const std::byte>(reinterpret_cast<const std::byte*>(span.rawData()), span.count() * sizeof(T));
+Span<const byte> AsBytes(Span<T> span) {
+    return Span<const byte>(reinterpret_cast<const byte*>(span.rawData()), span.count() * sizeof(T));
 }
 
 template <typename T>
-Span<std::byte> AsWritableBytes(Span<T> span) {
-    return Span<std::byte>(reinterpret_cast<std::byte*>(span.rawData()), span.count() * sizeof(T));
+Span<byte> AsWritableBytes(Span<T> span) {
+    return Span<byte>(reinterpret_cast<byte*>(span.rawData()), span.count() * sizeof(T));
 }
 
 template <typename T>
@@ -66,7 +68,7 @@ Core::Span<const T> ToSpan(std::initializer_list<T>& list) {
 }
 
 template <typename T>
-Core::Span<const std::byte> ToBytes(const T& value) requires std::is_trivially_copyable_v<T> {
+Core::Span<const byte> ToBytes(const T& value) requires std::is_trivially_copyable_v<T> {
     return AsBytes(Span<const T>(&value, 1));
 }
 
@@ -81,9 +83,9 @@ concept Spannable = requires(T a, const T b) {
     ->IsPointer;
 
     { a.size() }
-    ->std::convertible_to<uint64_t>;
+    ->std::convertible_to<u64>;
     { b.size() }
-    ->std::convertible_to<uint64_t>;
+    ->std::convertible_to<u64>;
 };
 
 template <Spannable T>

--- a/Core/containers/internal/Array.inl
+++ b/Core/containers/internal/Array.inl
@@ -8,7 +8,7 @@
 namespace Core {
 
 template <typename T>
-Array<T>::Array(uint64_t initialCapacity) : capacity(initialCapacity) {
+Array<T>::Array(u64 initialCapacity) : capacity(initialCapacity) {
     data = reinterpret_cast<T*>(malloc(capacity * ElementSize));
 }
 
@@ -19,9 +19,9 @@ Array<T>::Array(Core::Span<T> elementsToCopy) : capacity(elementsToCopy.count())
 }
 
 template <typename T>
-Array<T>::Array(const T& original, uint64_t repeatCount) : Array() {
+Array<T>::Array(const T& original, u64 repeatCount) : Array() {
     ensureCapacity(repeatCount);
-    for(uint64_t i = 0; i < repeatCount; i++) {
+    for(u64 i = 0; i < repeatCount; i++) {
         emplace(original);
     }
 }
@@ -93,20 +93,20 @@ Array<T>::~Array() {
 }
 
 template <typename T>
-T& Array<T>::operator[](uint64_t i) {
+T& Array<T>::operator[](u64 i) {
     ASSERT_WITH_MESSAGE(i < elementCount, "Index: {}, Count: {}", i, elementCount);
     return *(data + i);
 }
 
 template <typename T>
-const T& Array<T>::operator[](uint64_t i) const {
+const T& Array<T>::operator[](u64 i) const {
     ASSERT_WITH_MESSAGE(i < elementCount, "Index: {}, Count: {}", i, elementCount);
     return *(data + i);
 }
 
 template <typename T>
 template <typename... ARGS>
-T& Array<T>::emplaceAt(uint64_t index, ARGS&&... args) {
+T& Array<T>::emplaceAt(u64 index, ARGS&&... args) {
     ASSERT(index <= elementCount);
 
     if(index < elementCount) {
@@ -127,12 +127,12 @@ T& Array<T>::emplace(ARGS&&... args) {
 }
 
 template <typename T>
-T& Array<T>::insertAt(uint64_t index, const T& elementToInsert) {
+T& Array<T>::insertAt(u64 index, const T& elementToInsert) {
     return emplaceAt(index, elementToInsert);
 }
 
 template <typename T>
-T& Array<T>::insertAt(uint64_t index, T&& elementToInsert) {
+T& Array<T>::insertAt(u64 index, T&& elementToInsert) {
     if constexpr(std::is_move_constructible_v<T>) {
         return emplaceAt(index, std::move(elementToInsert));
     } else {
@@ -170,7 +170,7 @@ Core::Span<T> Array<T>::insertAll(Core::Span<U> elements) {
 }
 
 template <typename T>
-Core::Span<T> Array<T>::insertUninitialized(uint64_t newElementCount) {
+Core::Span<T> Array<T>::insertUninitialized(u64 newElementCount) {
     ensureCapacity(elementCount + newElementCount);
     elementCount += newElementCount;
 
@@ -178,7 +178,7 @@ Core::Span<T> Array<T>::insertUninitialized(uint64_t newElementCount) {
 }
 
 template <typename T>
-void Array<T>::eraseAt(uint64_t index, uint64_t elementsToErase) {
+void Array<T>::eraseAt(u64 index, u64 elementsToErase) {
     shiftElementsLeft(index + elementsToErase, elementsToErase);
 }
 
@@ -189,17 +189,17 @@ void Array<T>::clear() {
 }
 
 template <typename T>
-uint64_t Array<T>::count() const {
+u64 Array<T>::count() const {
     return elementCount;
 }
 
 template <typename T>
-uint64_t Array<T>::totalCapacity() const {
+u64 Array<T>::totalCapacity() const {
     return capacity;
 }
 
 template <typename T>
-uint64_t Array<T>::unusedCapacity() const {
+u64 Array<T>::unusedCapacity() const {
     return capacity - elementCount;
 }
 
@@ -239,13 +239,13 @@ const T* Array<T>::end() const {
 }
 
 template <typename T>
-void Array<T>::ensureCapacity(uint64_t requiredCapacity) {
+void Array<T>::ensureCapacity(u64 requiredCapacity) {
     if(requiredCapacity <= capacity) {
         return;
     }
 
     while(capacity < requiredCapacity) {
-        capacity = std::max(static_cast<uint64_t>(capacity * GrowthFactor), MinimumCapacity);
+        capacity = std::max(static_cast<u64>(capacity * GrowthFactor), MinimumCapacity);
     }
 
     T* newData = reinterpret_cast<T*>(malloc(capacity * ElementSize));
@@ -269,18 +269,18 @@ void Array<T>::destructAllElements() {
 }
 
 template <typename T>
-void Array<T>::CopyElementMemory(T* destination, const T* source, uint64_t elementCount) {
+void Array<T>::CopyElementMemory(T* destination, const T* source, u64 elementCount) {
     std::memcpy(destination, source, elementCount * ElementSize);
 }
 
 template <typename T>
-void Array<T>::MoveElementMemory(T* destination, const T* source, uint64_t elementCount) {
+void Array<T>::MoveElementMemory(T* destination, const T* source, u64 elementCount) {
     std::memmove(destination, source, elementCount * ElementSize);
 }
 
 
 template <typename T>
-void Array<T>::shiftElementsLeft(uint64_t startIndex, uint64_t distance) {
+void Array<T>::shiftElementsLeft(u64 startIndex, u64 distance) {
     ASSERT(distance <= startIndex);
 
     T* source      = data + startIndex;
@@ -293,7 +293,7 @@ void Array<T>::shiftElementsLeft(uint64_t startIndex, uint64_t distance) {
 }
 
 template <typename T>
-void Array<T>::shiftElementsRight(uint64_t startIndex, uint64_t distance) {
+void Array<T>::shiftElementsRight(u64 startIndex, u64 distance) {
     ensureCapacity(elementCount + distance);
 
     T* source      = data + startIndex;

--- a/Core/containers/internal/Span.inl
+++ b/Core/containers/internal/Span.inl
@@ -7,7 +7,7 @@
 namespace Core {
 
 template <typename T>
-Span<T>::Span(T* elements, uint64_t count) : elementCount(count), data(elements) {}
+Span<T>::Span(T* elements, u64 count) : elementCount(count), data(elements) {}
 
 template <typename T>
 template <typename U, typename>
@@ -25,18 +25,18 @@ Span<T>& Span<T>::operator=(Span<U> other) {
 }
 
 template <typename T>
-T& Span<T>::operator[](uint64_t i) {
+T& Span<T>::operator[](u64 i) {
     ASSERT_WITH_MESSAGE(i < elementCount, "Index: {}, Count: {}", i, elementCount);
     return *(data + i);
 }
 template <typename T>
-const T& Span<T>::operator[](uint64_t i) const {
+const T& Span<T>::operator[](u64 i) const {
     ASSERT_WITH_MESSAGE(i < elementCount, "Index: {}, Count: {}", i, elementCount);
     return *(data + i);
 }
 
 template <typename T>
-void Span<T>::truncateFront(uint64_t count) {
+void Span<T>::truncateFront(u64 count) {
     ASSERT_WITH_MESSAGE(count <= elementCount,
                         "Tried to truncate more than the span holds! Elements: {}, Truncate Amount: {}",
                         elementCount,
@@ -46,7 +46,7 @@ void Span<T>::truncateFront(uint64_t count) {
     elementCount -= count;
 }
 template <typename T>
-void Span<T>::truncateBack(uint64_t count) {
+void Span<T>::truncateBack(u64 count) {
     ASSERT_WITH_MESSAGE(count <= elementCount,
                         "Tried to truncate more than the span holds! Elements: {}, Truncate Amount: {}",
                         elementCount,
@@ -55,7 +55,7 @@ void Span<T>::truncateBack(uint64_t count) {
 }
 
 template <typename T>
-Span<T> Span<T>::first(uint64_t count) {
+Span<T> Span<T>::first(u64 count) {
     ASSERT_WITH_MESSAGE(count <= elementCount,
                         "Tried to get a subspan larger than the span! Elements: {}, Asked Count: {}",
                         elementCount,
@@ -63,7 +63,7 @@ Span<T> Span<T>::first(uint64_t count) {
     return Span(data, count);
 }
 template <typename T>
-Span<T> Span<T>::last(uint64_t count) {
+Span<T> Span<T>::last(u64 count) {
     ASSERT_WITH_MESSAGE(count <= elementCount,
                         "Tried to get a subspan larger than the span! Elements: {}, Asked Count: {}",
                         elementCount,
@@ -71,7 +71,7 @@ Span<T> Span<T>::last(uint64_t count) {
     return Span(data + elementCount - count, count);
 }
 template <typename T>
-Span<T> Span<T>::subspan(uint64_t offset, uint64_t count) const {
+Span<T> Span<T>::subspan(u64 offset, u64 count) const {
     ASSERT_WITH_MESSAGE(offset + count <= elementCount,
                         "Tried to get a subspan larger than the span! Elements: {}, Asked Offset: {}, Asked Count: {}",
                         elementCount,
@@ -81,7 +81,7 @@ Span<T> Span<T>::subspan(uint64_t offset, uint64_t count) const {
 }
 
 template <typename T>
-uint64_t Span<T>::count() const {
+u64 Span<T>::count() const {
     return elementCount;
 }
 template <typename T>

--- a/Core/containers/test/test_array.cpp
+++ b/Core/containers/test/test_array.cpp
@@ -1,6 +1,7 @@
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
 
+#include "core/Types.h"
 #include "core/containers/Array.h"
 #include "core/io/serialization/ArrayBuffer.h"
 #include "core/io/serialization/InputStream.h"
@@ -9,10 +10,10 @@
 #include <type_traits>
 
 struct Movable {
-    int id;
+    i32 id;
     bool movedFrom;
     bool movedTo;
-    Movable(int id) : id(id), movedFrom(false), movedTo(false) {}
+    Movable(i32 id) : id(id), movedFrom(false), movedTo(false) {}
     Movable(Movable&& other) : id(other.id), movedFrom(false), movedTo(true) {
         other.id        = -1;
         other.movedFrom = true;
@@ -29,10 +30,10 @@ std::ostream& operator<<(std::ostream& stream, const Movable& i) {
 }
 
 struct Copyable {
-    int id;
+    i32 id;
     bool copiedFrom;
     bool copiedTo;
-    Copyable(int id) : id(id), copiedFrom(false), copiedTo(false) {}
+    Copyable(i32 id) : id(id), copiedFrom(false), copiedTo(false) {}
     Copyable(Copyable&& other) = delete;
     Copyable(Copyable& other) : id(other.id), copiedFrom(false), copiedTo(true) {
         other.copiedFrom = true;
@@ -48,10 +49,10 @@ std::ostream& operator<<(std::ostream& stream, const Copyable& i) {
 }
 
 struct ConstCopyable {
-    int id;
+    i32 id;
     mutable bool copiedFrom;
     bool copiedTo;
-    ConstCopyable(int id) : id(id), copiedFrom(false), copiedTo(false) {}
+    ConstCopyable(i32 id) : id(id), copiedFrom(false), copiedTo(false) {}
     ConstCopyable(const ConstCopyable& other) : id(other.id), copiedFrom(false), copiedTo(true) {
         other.copiedFrom = true;
     }
@@ -67,12 +68,12 @@ std::ostream& operator<<(std::ostream& stream, const ConstCopyable& i) {
 }
 
 struct CopyMovable {
-    int id;
+    i32 id;
     bool movedFrom;
     bool movedTo;
     bool copiedFrom;
     bool copiedTo;
-    CopyMovable(int id) : id(id), movedFrom(false), movedTo(false), copiedFrom(false), copiedTo(false) {}
+    CopyMovable(i32 id) : id(id), movedFrom(false), movedTo(false), copiedFrom(false), copiedTo(false) {}
     CopyMovable(CopyMovable&& other)
       : id(other.id), movedFrom(false), movedTo(true), copiedFrom(false), copiedTo(false) {
         other.id        = -1;
@@ -93,12 +94,12 @@ std::ostream& operator<<(std::ostream& stream, const CopyMovable& i) {
 }
 
 struct ConstCopyMovable {
-    int id;
+    i32 id;
     bool movedFrom;
     bool movedTo;
     mutable bool copiedFrom;
     bool copiedTo;
-    ConstCopyMovable(int id) : id(id), movedFrom(false), movedTo(false), copiedFrom(false), copiedTo(false) {}
+    ConstCopyMovable(i32 id) : id(id), movedFrom(false), movedTo(false), copiedFrom(false), copiedTo(false) {}
     ConstCopyMovable(ConstCopyMovable&& other)
       : id(other.id), movedFrom(false), movedTo(true), copiedFrom(false), copiedTo(false) {
         other.id        = -1;
@@ -207,9 +208,9 @@ TEMPLATE_TEST_CASE("Resize Move", "", Movable, CopyMovable, ConstCopyMovable) {
 
     array.emplace(TestType(0));
 
-    TestType* firstElementPointer = array.begin();
+    TestType* firstElementPoi32er = array.begin();
 
-    while(array.begin() == firstElementPointer) {
+    while(array.begin() == firstElementPoi32er) {
         array.emplace(TestType(array.count()));
     }
 
@@ -223,9 +224,9 @@ TEMPLATE_TEST_CASE("Resize Copy", "", Copyable, ConstCopyable) {
 
     array.insert(TestType(0));
 
-    TestType* firstElementPointer = array.begin();
+    TestType* firstElementPoi32er = array.begin();
 
-    while(array.begin() == firstElementPointer) {
+    while(array.begin() == firstElementPoi32er) {
         array.insert(TestType(array.count()));
     }
 
@@ -235,28 +236,28 @@ TEMPLATE_TEST_CASE("Resize Copy", "", Copyable, ConstCopyable) {
 }
 
 TEST_CASE("No Arg Constructor") {
-    Core::Array<uint64_t> array;
+    Core::Array<u64> array;
     REQUIRE(array.count() == 0);
 }
 
 TEST_CASE("Initial Capacity Constructor") {
-    Core::Array<uint64_t> array(39);
+    Core::Array<u64> array(39);
     REQUIRE(array.count() == 0);
 }
 
-TEMPLATE_TEST_CASE("Repeating Constructor", "", uint64_t, ConstCopyable, ConstCopyMovable) {
-    constexpr uint64_t REPEAT_COUNT = 9;
+TEMPLATE_TEST_CASE("Repeating Constructor", "", u64, ConstCopyable, ConstCopyMovable) {
+    constexpr u64 REPEAT_COUNT = 9;
     TestType VALUE(1);
     Core::Array<TestType> array(VALUE, REPEAT_COUNT);
 
     REQUIRE(array.count() == REPEAT_COUNT);
-    for(uint64_t i = 0; i < REPEAT_COUNT; i++) {
+    for(u64 i = 0; i < REPEAT_COUNT; i++) {
         REQUIRE(array[i] == VALUE);
     }
 }
 
 TEST_CASE("Initializer List") {
-    Core::Array<uint64_t> array{1, 2, 3, 4, 5};
+    Core::Array<u64> array{1, 2, 3, 4, 5};
 
     REQUIRE(array.count() == 5);
     REQUIRE(array[0] == 1);
@@ -266,7 +267,7 @@ TEST_CASE("Initializer List") {
     REQUIRE(array[4] == 5);
 }
 
-TEMPLATE_TEST_CASE("Copy Constructor", "", uint64_t, ConstCopyable, ConstCopyMovable) {
+TEMPLATE_TEST_CASE("Copy Constructor", "", u64, ConstCopyable, ConstCopyMovable) {
     Core::Array<TestType> array;
 
     array.insert(TestType(1));
@@ -284,12 +285,12 @@ TEMPLATE_TEST_CASE("Copy Constructor", "", uint64_t, ConstCopyable, ConstCopyMov
     REQUIRE(array.count() == 8);
     REQUIRE(copy.count() == 5);
 
-    for(uint64_t i = 0; i < copy.count(); i++) {
+    for(u64 i = 0; i < copy.count(); i++) {
         REQUIRE(array[i] == copy[i]);
     }
 }
 
-TEMPLATE_TEST_CASE("Move Constructor", "", uint64_t, Movable, Copyable, CopyMovable, ConstCopyable, ConstCopyMovable) {
+TEMPLATE_TEST_CASE("Move Constructor", "", u64, Movable, Copyable, CopyMovable, ConstCopyable, ConstCopyMovable) {
     Core::Array<TestType> array;
 
     array.insert(TestType(1));
@@ -309,12 +310,12 @@ TEMPLATE_TEST_CASE("Move Constructor", "", uint64_t, Movable, Copyable, CopyMova
     REQUIRE(array.count() == 3);
     REQUIRE(copy.count() == 5);
 
-    for(uint64_t i = 0; i < copy.count(); i++) {
+    for(u64 i = 0; i < copy.count(); i++) {
         REQUIRE(copy[i] == TestType(i + 1));
     }
 }
 
-TEMPLATE_TEST_CASE("Copy Assignment", "", uint64_t, ConstCopyable, ConstCopyMovable) {
+TEMPLATE_TEST_CASE("Copy Assignment", "", u64, ConstCopyable, ConstCopyMovable) {
     Core::Array<TestType> array;
 
     array.insert(TestType(1));
@@ -333,12 +334,12 @@ TEMPLATE_TEST_CASE("Copy Assignment", "", uint64_t, ConstCopyable, ConstCopyMova
     REQUIRE(array.count() == 8);
     REQUIRE(copy.count() == 5);
 
-    for(uint64_t i = 0; i < copy.count(); i++) {
+    for(u64 i = 0; i < copy.count(); i++) {
         REQUIRE(array[i] == copy[i]);
     }
 }
 
-TEMPLATE_TEST_CASE("Move Assigmnet", "", uint64_t, Movable, Copyable, CopyMovable, ConstCopyable, ConstCopyMovable) {
+TEMPLATE_TEST_CASE("Move Assigmnet", "", u64, Movable, Copyable, CopyMovable, ConstCopyable, ConstCopyMovable) {
     Core::Array<TestType> array;
 
     array.insert(TestType(1));
@@ -359,12 +360,12 @@ TEMPLATE_TEST_CASE("Move Assigmnet", "", uint64_t, Movable, Copyable, CopyMovabl
     REQUIRE(array.count() == 3);
     REQUIRE(copy.count() == 5);
 
-    for(uint64_t i = 0; i < copy.count(); i++) {
+    for(u64 i = 0; i < copy.count(); i++) {
         REQUIRE(copy[i] == TestType(i + 1));
     }
 }
 
-TEMPLATE_TEST_CASE("Insert At", "", uint64_t, Movable, Copyable, ConstCopyable, CopyMovable, ConstCopyMovable) {
+TEMPLATE_TEST_CASE("Insert At", "", u64, Movable, Copyable, ConstCopyable, CopyMovable, ConstCopyMovable) {
     Core::Array<TestType> array;
 
     array.insert(TestType(0));
@@ -383,7 +384,7 @@ TEMPLATE_TEST_CASE("Insert At", "", uint64_t, Movable, Copyable, ConstCopyable, 
     REQUIRE(array[4] == TestType(3));
 }
 
-TEMPLATE_TEST_CASE("Emplace At", "", uint64_t, Movable, ConstCopyMovable) {
+TEMPLATE_TEST_CASE("Emplace At", "", u64, Movable, ConstCopyMovable) {
     Core::Array<TestType> array;
 
     array.emplace(TestType(0));
@@ -402,7 +403,7 @@ TEMPLATE_TEST_CASE("Emplace At", "", uint64_t, Movable, ConstCopyMovable) {
     REQUIRE(array[4] == TestType(3));
 }
 
-TEMPLATE_TEST_CASE("Erase At", "", uint64_t, Movable, Copyable, ConstCopyable, CopyMovable, ConstCopyMovable) {
+TEMPLATE_TEST_CASE("Erase At", "", u64, Movable, Copyable, ConstCopyable, CopyMovable, ConstCopyMovable) {
     Core::Array<TestType> array;
 
     array.insert(TestType(0));
@@ -420,7 +421,7 @@ TEMPLATE_TEST_CASE("Erase At", "", uint64_t, Movable, Copyable, ConstCopyable, C
 }
 
 
-TEMPLATE_TEST_CASE("Clear", "", uint64_t, Movable, Copyable, ConstCopyable, CopyMovable, ConstCopyMovable) {
+TEMPLATE_TEST_CASE("Clear", "", u64, Movable, Copyable, ConstCopyable, CopyMovable, ConstCopyMovable) {
     Core::Array<TestType> array;
 
     array.insert(TestType(0));
@@ -438,7 +439,7 @@ TEMPLATE_TEST_CASE("Clear", "", uint64_t, Movable, Copyable, ConstCopyable, Copy
 }
 
 TEST_CASE("Insert Uninitialized") {
-    constexpr uint64_t INSERT_COUNT = 8240;
+    constexpr u64 INSERT_COUNT = 8240;
 
     Core::Array<double> array;
 
@@ -456,8 +457,8 @@ TEST_CASE("Is Empty") {
     REQUIRE(!array.isEmpty());
 }
 
-TEMPLATE_TEST_CASE("Ensure Capacity", "", uint64_t, Movable, Copyable, ConstCopyable, CopyMovable, ConstCopyMovable) {
-    constexpr uint64_t ENSURED_CAPACITY = 637;
+TEMPLATE_TEST_CASE("Ensure Capacity", "", u64, Movable, Copyable, ConstCopyable, CopyMovable, ConstCopyMovable) {
+    constexpr u64 ENSURED_CAPACITY = 637;
 
     Core::Array<TestType> array;
 
@@ -465,16 +466,16 @@ TEMPLATE_TEST_CASE("Ensure Capacity", "", uint64_t, Movable, Copyable, ConstCopy
 
     array.insert(TestType(0));
 
-    TestType* firstElementPointer = array.begin();
+    TestType* firstElementPoi32er = array.begin();
 
-    while(array.begin() == firstElementPointer) {
+    while(array.begin() == firstElementPoi32er) {
         array.insert(TestType(array.count()));
     }
 
     REQUIRE(array.count() > ENSURED_CAPACITY);
 }
 
-TEMPLATE_TEST_CASE("Insert All", "", uint64_t, Copyable, ConstCopyable, CopyMovable, ConstCopyMovable) {
+TEMPLATE_TEST_CASE("Insert All", "", u64, Copyable, ConstCopyable, CopyMovable, ConstCopyMovable) {
     Core::Array<TestType> array;
 
     array.insert(TestType(0));
@@ -497,17 +498,17 @@ TEMPLATE_TEST_CASE("Insert All", "", uint64_t, Copyable, ConstCopyable, CopyMova
     REQUIRE(array.count() == 8);
     REQUIRE(array2.count() == 4);
 
-    for(uint64_t i = 0; i < array.count(); i++) {
+    for(u64 i = 0; i < array.count(); i++) {
         REQUIRE(array[i] == TestType(i));
     }
 }
 
 struct Trivial {
-    int a;
-    int b;
+    i32 a;
+    i32 b;
 
     Trivial() = default;
-    Trivial(int a, int b) : a(a), b(b) {}
+    Trivial(i32 a, i32 b) : a(a), b(b) {}
     bool operator==(const Trivial& other) const {
         return other.a == a && other.b == b;
     }
@@ -518,7 +519,7 @@ struct NonTrivial {
     Trivial b;
 
     NonTrivial() = default;
-    NonTrivial(int a, int b) : a(a, b), b(b, a) {}
+    NonTrivial(i32 a, i32 b) : a(a, b), b(b, a) {}
     NonTrivial(Trivial a, Trivial b) : a(a), b(b) {}
     NonTrivial(const NonTrivial& other) : a(other.a), b(other.b) {}
 
@@ -561,11 +562,11 @@ TEMPLATE_TEST_CASE("Serialize", "", Trivial, NonTrivial) {
     Core::Array<TestType> result = in.read<Core::Array<TestType>>();
 
     REQUIRE(result.count() == array.count());
-    for(uint64_t i = 0; i < array.count(); i++) {
+    for(u64 i = 0; i < array.count(); i++) {
         REQUIRE(result[i] == array[i]);
     }
 }
 
 TEST_CASE("No Implicit Integer Conversions") {
-    REQUIRE(!std::is_convertible_v<uint64_t, Core::Array<uint64_t>>);
+    REQUIRE(!std::is_convertible_v<u64, Core::Array<u64>>);
 }

--- a/Core/logging/BUILD
+++ b/Core/logging/BUILD
@@ -10,6 +10,7 @@ bengine_cc_library(
         "Logger.h",
     ],
     deps = [
+        "//core:types",
         "@fmt",
         "@spdlog",
     ],

--- a/Core/logging/Logger.h
+++ b/Core/logging/Logger.h
@@ -5,12 +5,13 @@
 #include <spdlog/common.h>
 #include <spdlog/logger.h>
 
+#include "core/Types.h"
 
 #include "LogCategory.h"
 
 namespace Core {
 
-enum class LogLevel : uint8_t { Trace = 0, Debug = 1, Info = 2, Warning = 3, Error = 4, Critical = 5, Always = 6 };
+enum class LogLevel : u8 { Trace = 0, Debug = 1, Info = 2, Warning = 3, Error = 4, Critical = 5, Always = 6 };
 
 namespace LogManager {
 void SetGlobalMinimumLevel(LogLevel minimumLevel);

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -151,21 +151,6 @@ http_archive(
     url = "https://github.com/catchorg/Catch2/archive/refs/tags/v3.3.1.zip",
 )
 
-###############
-# Setup boost #
-###############
-
-http_archive(
-    name = "com_github_nelhage_rules_boost",
-    sha256 = "6ae52932cbc21def3fad6772c814150f69bd7a0af9ad7da3bada074ee95b41ce",
-    strip_prefix = "rules_boost-812ba130cd895d142388d9b8fde7a66d9b3da6a5",
-    url = "https://github.com/nelhage/rules_boost/archive/812ba130cd895d142388d9b8fde7a66d9b3da6a5.zip",
-)
-
-load("@com_github_nelhage_rules_boost//:boost/boost.bzl", "boost_deps")
-
-boost_deps()
-
 #############
 # Setup fmt #
 #############

--- a/tools/bengine_rules.bzl
+++ b/tools/bengine_rules.bzl
@@ -3,14 +3,14 @@ load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
 def bengine_cc_binary(name, copts = None, **kwargs):
     cc_binary(
         name = name,
-        copts = ["-std:c++latest", "-Zc:__cplusplus"] + (copts or []),
+        copts = ["-std:c++latest", "-Zc:__cplusplus", "-permissive-"] + (copts or []),
         **kwargs
     )
 
 def bengine_cc_library(name, copts = None, **kwargs):
     cc_library(
         name = name,
-        copts = ["-std:c++latest", "-Zc:__cplusplus"] + (copts or []),
+        copts = ["-std:c++latest", "-Zc:__cplusplus", "-permissive-"] + (copts or []),
         **kwargs
     )
 
@@ -18,6 +18,6 @@ def bengine_cc_test(name, deps = None, copts = None, **kwargs):
     cc_test(
         name = name,
         deps = ["//tools:catch2_test_main"] + (deps or []),
-        copts = ["-std:c++latest", "-Zc:__cplusplus"] + (copts or []),
+        copts = ["-std:c++latest", "-Zc:__cplusplus", "-permissive-"] + (copts or []),
         **kwargs
     )


### PR DESCRIPTION
Also remove use of boost stacktrace in favour of std::stacktrace (fixes a windows header file inclusion issue, and removes the need for boost entirely)